### PR TITLE
Add master volume control

### DIFF
--- a/src/scriptune.js
+++ b/src/scriptune.js
@@ -1,4 +1,8 @@
 const audioContext = new AudioContext();
+const gain = audioContext.createGain();
+setMasterVolume(1);
+gain.connect(audioContext.destination);
+
 const pitches = {
     '-': 0,
     C1: 32.70, D1: 36.71, E1: 41.20, F1: 43.65, G1: 49.00, A1: 55.00, B1: 61.74,
@@ -17,28 +21,23 @@ const durations = {
  * @param {Number} frequency
  * @param {Number} duration
  * @param {'sine'|'square'|'sawtooth'|'triangle'} type
- * @param {Number} volume
  */
 async function beep (
     frequency,
     duration,
-    type = 'square',
-    volume = .1
+    type = 'square'
 ) {
     const oscillator = audioContext.createOscillator();
-    const gain = audioContext.createGain();
 
     oscillator.connect(gain);
-    gain.connect(audioContext.destination);
 
-    gain.gain.value = volume;
     oscillator.frequency.value = frequency;
     oscillator.type = type;
 
     oscillator.start();
     await new Promise(r => setTimeout(r, duration));
     oscillator.stop();
-};
+}
 
 function parseSheet(sheet) {
     const tracks = {default: []};
@@ -101,6 +100,13 @@ function parseSheet(sheet) {
 
 async function playTrack(notes) {
     for (const note of notes) await beep(note.pitch, note.duration, note.type);
+}
+
+/**
+ * @param {Number} value
+ */
+export function setMasterVolume(value) {
+    gain.gain.value = Math.max(0, Math.min(value, 1)) / 10;
 }
 
 export async function play(sheet) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -26,10 +26,14 @@
         There are a few example tunes to play with.
         Click on one of the buttons below to see the script and hear the tune!
     </p>
+    <label style="max-width: 250px;">
+        Volume
+        <input type="range" id="volume" value="1" step=".1" min="0" max="1">
+    </label>
     <div class="grid">
         <div>
-            <button id="tetris" class="outline">Tetris!</small></button>
-            <button id="ducklings" class="outline">All My Little Ducklings!</button>
+            <button data-sound="tetris" class="outline">Tetris!</small></button>
+            <button data-sound="ducklings" class="outline">All My Little Ducklings!</button>
         </div>
         <div>
             <article id="output">
@@ -39,21 +43,26 @@
     </div>
 </main>
 <script type="module">
-    import {play} from '../src/scriptune.js';
+    import {play, setMasterVolume} from '../src/scriptune.js';
 
+    const soundButtons = document.querySelectorAll('[data-sound]');
     const output = document.querySelector('#output');
 
-    document.querySelectorAll('button').forEach(e => e.addEventListener('click', async e => {
+    soundButtons.forEach(e => e.addEventListener('click', async e => {
         output.innerText = 'Loading sheet...';
-        document.querySelectorAll('button').forEach(e => e.disabled = true);
+        soundButtons.forEach(e => e.disabled = true);
 
-        const sheet = await (await (fetch(`sheet/${e.target.id}.txt`))).text();
+        const sheet = await (await (fetch(`sheet/${e.target.dataset.sound}.txt`))).text();
         output.innerText = sheet;
         await play(sheet);
 
-        document.querySelectorAll('button').forEach(e => e.disabled = false);
+        soundButtons.forEach(e => e.disabled = false);
         output.innerText = 'Select a tune to see the script!';
     }));
+
+    const volume = document.querySelector('#volume');
+    setMasterVolume(volume.value);
+    volume.addEventListener('input', e => setMasterVolume(e.target.value));
 </script>
 </body>
 </html>


### PR DESCRIPTION
Exports `setMasterVolume` to control the master volume on all connected audio nodes used by the module. It accepts a value between `0` and `1`, which is internally recalibrated to a maximum of `0.1` to prevent distortion.