### PR TITLE
Optimize note scheduling

### DIFF
--- a/src/scriptune.js
+++ b/src/scriptune.js
@@ -4,6 +4,7 @@
  * @typedef {{[key: string]: Note[]}} Tracks
  */
 
+const scheduleAheadInSeconds = 5;
 const audioContext = new AudioContext();
 const masterGain = audioContext.createGain();
 setMasterVolume(1);
@@ -135,7 +136,7 @@ async function playTrack(notes, currentTime, options) {
     let lastBeeps = [];
 
     for (const note of notes) {
-        if (currentTime - audioContext.currentTime > 5) await sleep(1000, options);
+        if (currentTime - audioContext.currentTime > scheduleAheadInSeconds) await sleep(1000, options);
         if (options.signal?.aborted) break;
 
         lastBeeps = note.pitches.map(pitch => beep(pitch, note, currentTime, options));

--- a/tests/index.html
+++ b/tests/index.html
@@ -104,7 +104,14 @@
             <a href="javascript:void(0)" class="outline" data-modal-open data-modal-sound="volume"
                data-modal-title="Adjust Volume!">Show notation</a>
         </article>
-        <div></div>
+        <article class="sheet">
+            <h4>Any Length!</h4>
+            <p>
+                Compose music from brief melodies to longer compositions without interruption.
+            </p>
+            <a href="javascript:void(0)" class="outline" data-modal-open data-modal-sound="long"
+               data-modal-title="Any Length!">Show notation</a>
+        </article>
     </div>
 </main>
 <footer class="container">

--- a/tests/sheet/long.txt
+++ b/tests/sheet/long.txt
@@ -1,0 +1,9 @@
+#LOOP 10
+    #BPM 3000
+    #LOOP 1000
+        C4:s
+    #ENDLOOP
+    C4:w -:w D4:w -:w E4:w -:w G4:w -:w
+#ENDLOOP
+C5:w -:w D5:w -:w E5:w -:w G5:w -:w
+C6:w -:w D6:w -:w E6:w -:w G6:w -:w


### PR DESCRIPTION
Notes are now timed using `AudioContext`'s internal clock instead of `setTimeout`, because `setTimeout` introduced jitter in certain scenarios, e.g. when switching tabs in some browsers or when a laptop’s battery is low.